### PR TITLE
[fix] Processor.Next

### DIFF
--- a/Sources/SKNodeBuilder/Foundation/Builder.swift
+++ b/Sources/SKNodeBuilder/Foundation/Builder.swift
@@ -28,7 +28,7 @@ public protocol BuilderProtocol {
 }
 
 public extension BuilderProtocol {
-    typealias Next<T: Modifier> = Link<Self, T> where T.Node == Self.Node
+    typealias Next<T: Modifier> = Link<Self, T> where T.Node == Self.Mod.Node
     typealias Node = Self.Mod.Node
     
     /// 定義されたビルダーからノードを生成します.


### PR DESCRIPTION
Xcode 14 以降からこのコードでエラーが発生するようになったため, 型制約の表現を修正した.