### PR TITLE
[remove] 全てのモディファイアの `@discardableResult` を削除しました.

### DIFF
--- a/Sources/SKNodeBuilder/Label/LabelProcessor.swift
+++ b/Sources/SKNodeBuilder/Label/LabelProcessor.swift
@@ -146,55 +146,55 @@ public enum LabelModifiers {
 
 public extension ProcessorProtocol where Node: SKLabelNode {
     
-    @discardableResult func text(_ value: String?) -> Next<LabelModifiers.Text<Node>> {
+    func text(_ value: String?) -> Next<LabelModifiers.Text<Node>> {
         self.modifier(mod: LabelModifiers.Text(body: value))
     }
     
-    @discardableResult func attributedText(_ value: NSAttributedString) -> Next<LabelModifiers.AttributedText<Node>> {
+    func attributedText(_ value: NSAttributedString) -> Next<LabelModifiers.AttributedText<Node>> {
         self.modifier(mod: LabelModifiers.AttributedText(body: value))
     }
     
-    @discardableResult func fontColor(_ value: SKColor?) -> Next<LabelModifiers.FontColor<Node>> {
+    func fontColor(_ value: SKColor?) -> Next<LabelModifiers.FontColor<Node>> {
         self.modifier(mod: LabelModifiers.FontColor(body: value))
     }
     
-    @discardableResult func fontName(_ value: String?) -> Next<LabelModifiers.FontName<Node>> {
+    func fontName(_ value: String?) -> Next<LabelModifiers.FontName<Node>> {
         self.modifier(mod: LabelModifiers.FontName(body: value))
     }
     
-    @discardableResult func fontSize(_ value: CGFloat) -> Next<LabelModifiers.FontSize<Node>> {
+    func fontSize(_ value: CGFloat) -> Next<LabelModifiers.FontSize<Node>> {
         self.modifier(mod: LabelModifiers.FontSize(body: value))
     }
     
-    @discardableResult func verticalAlignment(_ value: SKLabelVerticalAlignmentMode) -> Next<LabelModifiers.VerticalAlignment<Node>> {
+    func verticalAlignment(_ value: SKLabelVerticalAlignmentMode) -> Next<LabelModifiers.VerticalAlignment<Node>> {
         self.modifier(mod: LabelModifiers.VerticalAlignment(body: value))
     }
     
-    @discardableResult func horizontalAlignment(_ value: SKLabelHorizontalAlignmentMode) -> Next<LabelModifiers.HorizontalAlignment<Node>> {
+    func horizontalAlignment(_ value: SKLabelHorizontalAlignmentMode) -> Next<LabelModifiers.HorizontalAlignment<Node>> {
         self.modifier(mod: LabelModifiers.HorizontalAlignment(body: value))
     }
     
-    @discardableResult func preferredMaxLayoutWidth(_ value: CGFloat) -> Next<LabelModifiers.PreferredMaxLayoutWidth<Node>> {
+    func preferredMaxLayoutWidth(_ value: CGFloat) -> Next<LabelModifiers.PreferredMaxLayoutWidth<Node>> {
         self.modifier(mod: LabelModifiers.PreferredMaxLayoutWidth(body: value))
     }
     
-    @discardableResult func lineBreakMode(_ value: NSLineBreakMode) -> Next<LabelModifiers.LineBreakMode<Node>> {
+    func lineBreakMode(_ value: NSLineBreakMode) -> Next<LabelModifiers.LineBreakMode<Node>> {
         self.modifier(mod: LabelModifiers.LineBreakMode(body: value))
     }
     
-    @discardableResult func numberOfLines(_ value: Int) -> Next<LabelModifiers.NumberOfLines<Node>> {
+    func numberOfLines(_ value: Int) -> Next<LabelModifiers.NumberOfLines<Node>> {
         self.modifier(mod: LabelModifiers.NumberOfLines(body: value))
     }
     
-    @discardableResult func color(_ value: SKColor) -> Next<LabelModifiers.Color<Node>> {
+    func color(_ value: SKColor) -> Next<LabelModifiers.Color<Node>> {
         self.modifier(mod: LabelModifiers.Color(body: value))
     }
     
-    @discardableResult func colorBlendFactor(_ value: CGFloat) -> Next<LabelModifiers.ColorBlendFactor<Node>> {
+    func colorBlendFactor(_ value: CGFloat) -> Next<LabelModifiers.ColorBlendFactor<Node>> {
         self.modifier(mod: LabelModifiers.ColorBlendFactor(body: value))
     }
     
-    @discardableResult func blendMode(_ value: SKBlendMode) -> Next<LabelModifiers.BlendMode<Node>> {
+    func blendMode(_ value: SKBlendMode) -> Next<LabelModifiers.BlendMode<Node>> {
         self.modifier(mod: LabelModifiers.BlendMode(body: value))
     }
 

--- a/Sources/SKNodeBuilder/Node/SKNodeProcessor.swift
+++ b/Sources/SKNodeBuilder/Node/SKNodeProcessor.swift
@@ -151,49 +151,49 @@ extension StandardModifiers.AddChildBuilder: Modifier where Generator: DefaultNo
 public extension ProcessorProtocol {
     
     /// 座標を変更します.
-    @discardableResult func position(_ value: CGPoint) -> Next<StandardModifiers.Position<Node>> {
+    func position(_ value: CGPoint) -> Next<StandardModifiers.Position<Node>> {
         self.modifier(mod: StandardModifiers.Position(body: value))
     }
     
     /// スケールを変更します.
-    @discardableResult func setScale(_ value: CGFloat) -> Next<StandardModifiers.Scale<Node>> {
+    func setScale(_ value: CGFloat) -> Next<StandardModifiers.Scale<Node>> {
         self.modifier(mod: StandardModifiers.Scale(body: value))
     }
     
     /// x スケールを変更します.
-    @discardableResult func xScale(_ value: CGFloat) -> Next<StandardModifiers.XScale<Node>> {
+    func xScale(_ value: CGFloat) -> Next<StandardModifiers.XScale<Node>> {
         self.modifier(mod: StandardModifiers.XScale(body: value))
     }
     
     /// y スケールを変更します.
-    @discardableResult func yScale(_ value: CGFloat) -> Next<StandardModifiers.YScale<Node>> {
+    func yScale(_ value: CGFloat) -> Next<StandardModifiers.YScale<Node>> {
         self.modifier(mod: StandardModifiers.YScale(body: value))
     }
     
     /// zPosition を変更します.
-    @discardableResult func zPosition(_ value: CGFloat) -> Next<StandardModifiers.ZPosition<Node>> {
+    func zPosition(_ value: CGFloat) -> Next<StandardModifiers.ZPosition<Node>> {
         self.modifier(mod: StandardModifiers.ZPosition(body: value))
     }
     
     /// zRotation を変更します.
-    @discardableResult func zRotation(_ value: CGFloat) -> Next<StandardModifiers.ZRotation<Node>> {
+    func zRotation(_ value: CGFloat) -> Next<StandardModifiers.ZRotation<Node>> {
         self.modifier(mod: StandardModifiers.ZRotation(body: value))
     }
     
     /// alpha を変更します.
-    @discardableResult func alpha(_ value: CGFloat) -> Next<StandardModifiers.Alpha<Node>> {
+    func alpha(_ value: CGFloat) -> Next<StandardModifiers.Alpha<Node>> {
         self.modifier(mod: StandardModifiers.Alpha(body: value))
     }
     
     /// name を変更します.
-    @discardableResult func name(_ value: String?) -> Next<StandardModifiers.Name<Node>> {
+    func name(_ value: String?) -> Next<StandardModifiers.Name<Node>> {
         self.modifier(mod: StandardModifiers.Name(body: value))
     }
     
     /// 子ノードをビルダーで作成し, 追加します.
     ///
     /// [Modifier](doc:SKNodeBuilder/StandardModifiers/AddChildBuilder) をラップしたメソッドです.
-    @discardableResult func addChild<Generator: GeneratorProtocol, T: ProcessorProtocol>(builder value: Builder<Generator, T>) -> Next<StandardModifiers.AddChildBuilder<Generator, T, Node>> where Generator: DefaultNodeGenerator {
+    func addChild<Generator: GeneratorProtocol, T: ProcessorProtocol>(builder value: Builder<Generator, T>) -> Next<StandardModifiers.AddChildBuilder<Generator, T, Node>> where Generator: DefaultNodeGenerator {
         self.modifier(mod: StandardModifiers.AddChildBuilder(body: value))
     }
     
@@ -202,7 +202,7 @@ public extension ProcessorProtocol {
     /// [Modifier](doc:SKNodeBuilder/StandardModifiers/AddChildWithNode) をラップしたメソッドです.
     /// - attention: `process(node:)` など, 編集フローとしてビルダーを使用する場合, 子ノードの取り合いが発生することがあります.
     /// - attention: 引数に `SKSpriteNode(color:, size:)` のように直接インスタンス化して参照をセットすると, エラーが起こります. これはModifier が参照を unowned で所持するためです. 直接インスタンス化したい場合は `addChild<T: ProcessorProtocol>(_ : T)` を使ってください.
-    @discardableResult func addChild<T: ProcessorProtocol>(_ value: T, withNode node: T.Node) -> Next<StandardModifiers.AddChildWithNode<T, Node>> {
+    func addChild<T: ProcessorProtocol>(_ value: T, withNode node: T.Node) -> Next<StandardModifiers.AddChildWithNode<T, Node>> {
         self.modifier(mod: StandardModifiers.AddChildWithNode(body: value, childNode: node))
     }
     
@@ -211,7 +211,7 @@ public extension ProcessorProtocol {
     /// [Modifier](doc:SKNodeBuilder/StandardModifiers/AddChild) をラップしたメソッドです.
     /// - attention: `process(node:)` など, 編集フローとしてビルダーを使用する場合, 子ノードの取り合いが発生することがあります.
     /// - attention: 引数に `SKSpriteNode(color:, size:)` のように直接インスタンス化して参照をセットすると, エラーが起こります. これはModifier が参照を unowned で所持するためです. 直接インスタンス化したい場合は `addChild<T: ProcessorProtocol>(_ : T)` を使ってください.
-    @discardableResult func addChild<T: SKNode>(_ value: T) -> Next<StandardModifiers.AddChild<T, Node>> {
+    func addChild<T: SKNode>(_ value: T) -> Next<StandardModifiers.AddChild<T, Node>> {
         self.modifier(mod: StandardModifiers.AddChild(body: value))
     }
     

--- a/Sources/SKNodeBuilder/Shape/ShapeProcessor.swift
+++ b/Sources/SKNodeBuilder/Shape/ShapeProcessor.swift
@@ -166,63 +166,63 @@ public enum ShapeModifiers {
 
 public extension ProcessorProtocol where Node: SKShapeNode {
     
-    @discardableResult func path(_ value: CGPath?) -> Next<ShapeModifiers.Path<Node>> {
+    func path(_ value: CGPath?) -> Next<ShapeModifiers.Path<Node>> {
         self.modifier(mod: ShapeModifiers.Path(body: value))
     }
     
-    @discardableResult func fillColor(_ value: SKColor) -> Next<ShapeModifiers.FillColor<Node>> {
+    func fillColor(_ value: SKColor) -> Next<ShapeModifiers.FillColor<Node>> {
         self.modifier(mod: ShapeModifiers.FillColor(body: value))
     }
     
-    @discardableResult func fillTexture(_ value: SKTexture?) -> Next<ShapeModifiers.FillTexture<Node>> {
+    func fillTexture(_ value: SKTexture?) -> Next<ShapeModifiers.FillTexture<Node>> {
         self.modifier(mod: ShapeModifiers.FillTexture(body: value))
     }
     
-    @discardableResult func lineWidth(_ value: CGFloat) -> Next<ShapeModifiers.LineWidth<Node>> {
+    func lineWidth(_ value: CGFloat) -> Next<ShapeModifiers.LineWidth<Node>> {
         self.modifier(mod: ShapeModifiers.LineWidth(body: value))
     }
     
-    @discardableResult func strokeColor(_ value: SKColor) -> Next<ShapeModifiers.StrokeColor<Node>> {
+    func strokeColor(_ value: SKColor) -> Next<ShapeModifiers.StrokeColor<Node>> {
         self.modifier(mod: ShapeModifiers.StrokeColor(body: value))
     }
     
-    @discardableResult func strokeTexture(_ value: SKTexture?) -> Next<ShapeModifiers.StrokeTexture<Node>> {
+    func strokeTexture(_ value: SKTexture?) -> Next<ShapeModifiers.StrokeTexture<Node>> {
         self.modifier(mod: ShapeModifiers.StrokeTexture(body: value))
     }
     
-    @discardableResult func glowWidth(_ value: CGFloat) -> Next<ShapeModifiers.GlowWidth<Node>> {
+    func glowWidth(_ value: CGFloat) -> Next<ShapeModifiers.GlowWidth<Node>> {
         self.modifier(mod: ShapeModifiers.GlowWidth(body: value))
     }
     
-    @discardableResult func lineCap(_ value: CGLineCap) -> Next<ShapeModifiers.LineCap<Node>> {
+    func lineCap(_ value: CGLineCap) -> Next<ShapeModifiers.LineCap<Node>> {
         self.modifier(mod: ShapeModifiers.LineCap(body: value))
     }
     
-    @discardableResult func lineJoin(_ value: CGLineJoin) -> Next<ShapeModifiers.LineJoin<Node>> {
+    func lineJoin(_ value: CGLineJoin) -> Next<ShapeModifiers.LineJoin<Node>> {
         self.modifier(mod: ShapeModifiers.LineJoin(body: value))
     }
     
-    @discardableResult func miterLimit(_ value: CGFloat) -> Next<ShapeModifiers.MiterLimit<Node>> {
+    func miterLimit(_ value: CGFloat) -> Next<ShapeModifiers.MiterLimit<Node>> {
         self.modifier(mod: ShapeModifiers.MiterLimit(body: value))
     }
     
-    @discardableResult func isAntialiased(_ value: Bool) -> Next<ShapeModifiers.IsAntialiased<Node>> {
+    func isAntialiased(_ value: Bool) -> Next<ShapeModifiers.IsAntialiased<Node>> {
         self.modifier(mod: ShapeModifiers.IsAntialiased(body: value))
     }
     
-    @discardableResult func blendMode(_ value: SKBlendMode) -> Next<ShapeModifiers.BlendMode<Node>> {
+    func blendMode(_ value: SKBlendMode) -> Next<ShapeModifiers.BlendMode<Node>> {
         self.modifier(mod: ShapeModifiers.BlendMode(body: value))
     }
     
-    @discardableResult func strokeShader(_ value: SKShader?) -> Next<ShapeModifiers.StrokeShader<Node>> {
+    func strokeShader(_ value: SKShader?) -> Next<ShapeModifiers.StrokeShader<Node>> {
         self.modifier(mod: ShapeModifiers.StrokeShader(body: value))
     }
     
-    @discardableResult func fillShader(_ value: SKShader?) -> Next<ShapeModifiers.FillShader<Node>> {
+    func fillShader(_ value: SKShader?) -> Next<ShapeModifiers.FillShader<Node>> {
         self.modifier(mod: ShapeModifiers.FillShader(body: value))
     }
     
-    @discardableResult func attributeValues(_ value: [String: SKAttributeValue]) -> Next<ShapeModifiers.AttributeValues<Node>> {
+    func attributeValues(_ value: [String: SKAttributeValue]) -> Next<ShapeModifiers.AttributeValues<Node>> {
         self.modifier(mod: ShapeModifiers.AttributeValues(body: value))
     }
     

--- a/Sources/SKNodeBuilder/Sprite/SpriteProcessor.swift
+++ b/Sources/SKNodeBuilder/Sprite/SpriteProcessor.swift
@@ -147,55 +147,55 @@ public enum SpriteModifiers {
 
 public extension ProcessorProtocol where Node: SKSpriteNode {
     
-    @discardableResult func texture(_ value: SKTexture) -> Next<SpriteModifiers.Texture<Node>> {
+    func texture(_ value: SKTexture) -> Next<SpriteModifiers.Texture<Node>> {
         self.modifier(mod: SpriteModifiers.Texture(body: value))
     }
     
-    @discardableResult func size(_ value: CGSize) -> Next<SpriteModifiers.Size<Node>> {
+    func size(_ value: CGSize) -> Next<SpriteModifiers.Size<Node>> {
         self.modifier(mod: SpriteModifiers.Size(body: value))
     }
     
-    @discardableResult func anchorPoint(_ value: CGPoint) -> Next<SpriteModifiers.AnchorPoint<Node>> {
+    func anchorPoint(_ value: CGPoint) -> Next<SpriteModifiers.AnchorPoint<Node>> {
         self.modifier(mod: SpriteModifiers.AnchorPoint(body: value))
     }
     
-    @discardableResult func centerRect(_ value: CGRect) -> Next<SpriteModifiers.CenterRect<Node>> {
+    func centerRect(_ value: CGRect) -> Next<SpriteModifiers.CenterRect<Node>> {
         self.modifier(mod: SpriteModifiers.CenterRect(body: value))
     }
     
-    @discardableResult func color(_ value: SKColor) -> Next<SpriteModifiers.Color<Node>> {
+    func color(_ value: SKColor) -> Next<SpriteModifiers.Color<Node>> {
         self.modifier(mod: SpriteModifiers.Color(body: value))
     }
     
-    @discardableResult func colorBlendFactor(_ value: CGFloat) -> Next<SpriteModifiers.ColorBlendFactor<Node>> {
+    func colorBlendFactor(_ value: CGFloat) -> Next<SpriteModifiers.ColorBlendFactor<Node>> {
         self.modifier(mod: SpriteModifiers.ColorBlendFactor(body: value))
     }
     
-    @discardableResult func blendMode(_ value: SKBlendMode) -> Next<SpriteModifiers.BlendMode<Node>> {
+    func blendMode(_ value: SKBlendMode) -> Next<SpriteModifiers.BlendMode<Node>> {
         self.modifier(mod: SpriteModifiers.BlendMode(body: value))
     }
     
-    @discardableResult func lightingBitMask(_ value: UInt32) -> Next<SpriteModifiers.LightingBitMask<Node>> {
+    func lightingBitMask(_ value: UInt32) -> Next<SpriteModifiers.LightingBitMask<Node>> {
         self.modifier(mod: SpriteModifiers.LightingBitMask(body: value))
     }
     
-    @discardableResult func shadowedBitMask(_ value: UInt32) -> Next<SpriteModifiers.ShadowedBitMask<Node>> {
+    func shadowedBitMask(_ value: UInt32) -> Next<SpriteModifiers.ShadowedBitMask<Node>> {
         self.modifier(mod: SpriteModifiers.ShadowedBitMask(body: value))
     }
     
-    @discardableResult func shadowCastBitMask(_ value: UInt32) -> Next<SpriteModifiers.ShadowCastBitMask<Node>> {
+    func shadowCastBitMask(_ value: UInt32) -> Next<SpriteModifiers.ShadowCastBitMask<Node>> {
         self.modifier(mod: SpriteModifiers.ShadowCastBitMask(body: value))
     }
     
-    @discardableResult func normalTexture(_ value: SKTexture?) -> Next<SpriteModifiers.NormalTexture<Node>> {
+    func normalTexture(_ value: SKTexture?) -> Next<SpriteModifiers.NormalTexture<Node>> {
         self.modifier(mod: SpriteModifiers.NormalTexture(body: value))
     }
     
-    @discardableResult func shader(_ value: SKShader?) -> Next<SpriteModifiers.Shader<Node>> {
+    func shader(_ value: SKShader?) -> Next<SpriteModifiers.Shader<Node>> {
         self.modifier(mod: SpriteModifiers.Shader(body: value))
     }
     
-    @discardableResult func setValue(_ value: SKAttributeValue, forAttribute key: String) -> Next<SpriteModifiers.SetValue<Node>> {
+    func setValue(_ value: SKAttributeValue, forAttribute key: String) -> Next<SpriteModifiers.SetValue<Node>> {
         self.modifier(mod: SpriteModifiers.SetValue(value: value, key: key))
     }
     


### PR DESCRIPTION
#82  Builder や Processor は必ず変数に代入するか, `node()` を実行することがわかっているため, 必要ないという結論になりました.